### PR TITLE
docs(livrables): ajoute placeholders officiels P1→P6 et met à jour RE…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,57 @@
 ﻿# HF-Project
 
-Proof of Concept (POC) industriel : conception d’une solution RF sur PCB intégrant ESP32, GPS, LoRa 868 MHz et une antenne dédiée, avec simulation, implémentation et caractérisation.
+Proof of Concept (POC) industriel : conception d’une solution RF sur PCB intégrant **ESP32, GPS, LoRa 868 MHz et une antenne dédiée**, avec **simulation, implémentation et caractérisation**.
 
 ---
 
-## Objectif
-- Démontrer une chaîne hardware + software fonctionnelle :
+## Objectifs
+- Démontrer une chaîne **hardware + software fonctionnelle** :
   - Carte embarquée (ESP32, GPS, LoRa, PMIC, USB-C).
   - Carte antenne PCB 868 MHz conçue, simulée et caractérisée.
   - Firmware de démonstration : LoRa ping/pong, GPS NMEA, Wi-Fi/BLE scan.
-- Fournir une documentation style carte de développement (datasheet, quickstart, tutoriels).
-- Tenir un journal de bord continu servant de base au rapport final.
+- Fournir une documentation **style carte de développement** (datasheet, quickstart, tutoriels).
+- Tenir un **journal de bord continu** servant de base au rapport final.
 
 ---
 
-## Plan de projet
-Le projet est découpé en 6 phases, chacune avec livrables.
+## Livrables officiels (évalués)
 
-- [Project Plan complet](project/PROJECT_PLAN.md)
+Les phases du projet suivent la grille imposée par l’enseignant, chaque livrable est noté.
+
+1. **PCB embarqué (Phase 1)**
+   - Carte ESP32 + GPS + LoRa + PMIC + USB-C  
+   - Fichiers de fabrication : [Gerbers](hardware/fabrication/Gerbers/), [BOM.csv](hardware/fabrication/BOM.csv), [Pick&Place.csv](hardware/fabrication/PickPlace.csv)
+
+2. **Software & Lab concept (Phase 2)**
+   - Firmware minimal : [`/firmware/esp32/`](firmware/esp32/)  
+   - Premiers résultats labo : [`/tests/reports/lab_concept/`](tests/reports/lab_concept/)  
+   - Choix de l’antenne : [Stratégie antenne](project/06_Strategie_Antenne.md)
+
+3. **Antenne 868 MHz (Phase 3)**
+   - Design simulé : [`/hardware/antenna/openems/`](hardware/antenna/openems/), [`/hardware/antenna/qucs/`](hardware/antenna/qucs/)  
+   - Résultats S11 : [`s11_sim.csv`](hardware/antenna/results/s11_sim.csv)  
+   - PCB antenne dédié : [`/hardware/antenna/`](hardware/antenna/)
+
+4. **Protocoles & tests (Phase 4)**
+   - Protocole VNA : [`plan_vna.md`](tests/rf/plan_vna.md)  
+   - Pré-scan EMI/CEM : [`pre_scan_plan.md`](hardware/emi_cem/pre_scan_plan.md)  
+   - Protocoles fonctionnels : [`protocoles.md`](tests/functional/protocoles.md)
+
+5. **Tests instrumentés (Phase 5)**
+   - S11 mesuré : [`s11_meas.csv`](tests/reports/instrumented/s11_meas.csv)  
+   - Rapports de mesures : [`/tests/reports/instrumented/`](tests/reports/instrumented/)
+
+6. **Examen oral & rapport (Phase 6)**
+   - Présentation : [`/docs/slides/`](docs/slides/)  
+   - Rapport final : [`Rapport_Final.md`](docs/report/Rapport_Final.md)
+
+
+---
+
+## Livrables internes (organisation & suivi)
+Ces documents structurent le projet et préparent le rapport.
+
+- [Project Plan complet](project/PROJECT_PLAN.md)  
 - Sections détaillées :
   1. [Vision & DoD](project/01_Vision_DoD.md)  
   2. [WBS & RACI](project/02_WBS_RACI.md)  
@@ -34,20 +68,20 @@ Le projet est découpé en 6 phases, chacune avec livrables.
 
 ## Structure du repo
 
-- `/project/` → plan de projet (sections 01–10).  
-- `/docs/` → documentation utilisateur (datasheet, quickstart, tutoriels, images).  
-- `/hardware/` → schémas KiCad, Gerbers, antenne, EMI/CEM.  
-- `/firmware/` → drivers ESP32 + exemples.  
-- `/tests/` → plans, scripts et rapports de tests.  
-- `/logs/` → journal de bord (suivi continu).  
-- `/ci/` → workflows CI/CD.  
-- `/.github/` → templates issues/PR.  
+- `/project/` → plan de projet (sections 01–10)  
+- `/docs/` → documentation utilisateur (datasheet, quickstart, tutoriels, images)  
+- `/hardware/` → schémas KiCad, Gerbers, antenne, EMI/CEM  
+- `/firmware/` → drivers ESP32 + exemples  
+- `/tests/` → plans, scripts et rapports de tests  
+- `/logs/` → journal de bord continu  
+- `/ci/` → workflows CI/CD  
+- `/.github/` → templates Issues & PR  
 
 ---
 
 ## Journal de bord
 - [Index du journal](logs/journal_index.md)  
-- Journaux individuels : `/logs/journal/YYYY-MM-DD.md`
+- Journaux individuels : `logs/journal/YYYY-MM-DD.md`  
 
 ---
 
@@ -63,7 +97,7 @@ Le projet est découpé en 6 phases, chacune avec livrables.
 ### Hardware
 - Schémas et PCB : [`/hardware/kicad/`](hardware/kicad/)  
 - Gerbers + BOM : [`/hardware/fabrication/`](hardware/fabrication/)  
-- Antenne PCB 868 MHz : [`/hardware/antenna/`](hardware/antenna/)  
+- Antenne 868 MHz : [`/hardware/antenna/`](hardware/antenna/)  
 
 ### Firmware
 - ESP32 + drivers : [`/firmware/esp32/`](firmware/esp32/)  
@@ -78,10 +112,10 @@ Le projet est découpé en 6 phases, chacune avec livrables.
 
 ## CI/CD
 Workflows dans [`/ci/workflows/`](ci/workflows/) :
-- `drc_erc.yml` : vérification ERC/DRC KiCad.  
-- `firmware_build.yml` : build & lint firmware.  
-- `export_gerbers.yml` : artefacts Gerbers + BOM.  
-- `tests.yml` : exécution scripts Python (mesures/tests).  
+- `drc_erc.yml` → vérification ERC/DRC KiCad  
+- `firmware_build.yml` → build & lint firmware  
+- `export_gerbers.yml` → artefacts Gerbers + BOM  
+- `tests.yml` → exécution scripts Python  
 
 ---
 
@@ -93,4 +127,4 @@ Workflows dans [`/ci/workflows/`](ci/workflows/) :
 
 ---
 
-Équipe HF-Project — projet académique RF/embedded 2025.
+Équipe **HF-Project** — projet académique RF/embedded 2025.

--- a/docs/datasheet/Board_Datasheet.md
+++ b/docs/datasheet/Board_Datasheet.md
@@ -1,0 +1,2 @@
+﻿# Datasheet – Sommaire
+- Vue d'ensemble, specs, pinout, consommation, interfaces.

--- a/docs/quickstart/Quickstart.md
+++ b/docs/quickstart/Quickstart.md
@@ -1,0 +1,2 @@
+﻿# Quickstart
+- Alim, flash firmware, premiers tests (LoRa/GPS/Wi-Fi).

--- a/docs/report/Rapport_Final.md
+++ b/docs/report/Rapport_Final.md
@@ -1,0 +1,2 @@
+﻿# Rapport final (Phase 6)
+- Compile le journal + résultats + annexes.

--- a/docs/slides/README.md
+++ b/docs/slides/README.md
@@ -1,0 +1,2 @@
+﻿# Slides (Phase 6)
+- Dépose la présentation finale.

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,2 @@
+﻿# Tutoriels
+- Mesure S11, OpenEMS, Qucs, range test LoRa, GPS TTFF.

--- a/firmware/esp32/README.md
+++ b/firmware/esp32/README.md
@@ -1,0 +1,2 @@
+﻿# Firmware ESP32 (Phase 2)
+- Exemples : LoRa ping/pong, GPS NMEA, Wi-Fi/BLE scan.

--- a/hardware/antenna/README.md
+++ b/hardware/antenna/README.md
@@ -1,0 +1,2 @@
+﻿# Antenne 868 MHz (Phase 3)
+- Modèles OpenEMS, matching Qucs, résultats S11.

--- a/hardware/antenna/openems/README.md
+++ b/hardware/antenna/openems/README.md
@@ -1,0 +1,2 @@
+﻿# OpenEMS
+- Place le modèle (.xml / .m), scripts et paramètres.

--- a/hardware/antenna/qucs/README.md
+++ b/hardware/antenna/qucs/README.md
@@ -1,0 +1,2 @@
+﻿# Qucs / QucsStudio
+- Place le schéma du réseau d'adaptation (π/LC).

--- a/hardware/antenna/results/s11_sim.csv
+++ b/hardware/antenna/results/s11_sim.csv
@@ -1,0 +1,1 @@
+﻿freq_MHz,S11_dB

--- a/hardware/emi_cem/pre_scan_plan.md
+++ b/hardware/emi_cem/pre_scan_plan.md
@@ -1,0 +1,2 @@
+﻿# Pré-scan EMI/CEM (Phase 4)
+- Méthodes, limites, captures spectre.

--- a/hardware/fabrication/BOM.csv
+++ b/hardware/fabrication/BOM.csv
@@ -1,0 +1,1 @@
+﻿RefDesignator,Quantity,Manufacturer,MPN,Description

--- a/hardware/fabrication/Gerbers/README.md
+++ b/hardware/fabrication/Gerbers/README.md
@@ -1,0 +1,2 @@
+﻿# Gerbers
+Dépose ici les fichiers .gbr / .drl exportés.

--- a/hardware/fabrication/PickPlace.csv
+++ b/hardware/fabrication/PickPlace.csv
@@ -1,0 +1,1 @@
+﻿Designator,Package,Center-X(mm),Center-Y(mm),Rotation,Side

--- a/hardware/fabrication/README.md
+++ b/hardware/fabrication/README.md
@@ -1,0 +1,2 @@
+﻿# Fabrication (Phase 1)
+- Dépose ici : Gerbers, BOM, Pick&Place.

--- a/tests/functional/protocoles.md
+++ b/tests/functional/protocoles.md
@@ -1,0 +1,2 @@
+﻿# Protocoles fonctionnels (Phase 4)
+- LoRa ping/pong, GPS TTFF, Wi-Fi scan, puissance.

--- a/tests/reports/instrumented/README.md
+++ b/tests/reports/instrumented/README.md
@@ -1,0 +1,2 @@
+﻿# Rapports de mesures (Phase 5)
+- BW à -10 dB, rendement, spectre, portée LoRa, GPS TTFF.

--- a/tests/reports/instrumented/s11_meas.csv
+++ b/tests/reports/instrumented/s11_meas.csv
@@ -1,0 +1,1 @@
+﻿freq_MHz,S11_dB

--- a/tests/reports/lab_concept/README.md
+++ b/tests/reports/lab_concept/README.md
@@ -1,0 +1,2 @@
+﻿# Résultats labo initiaux (Phase 2)
+- Captures logs, mesures rapides, décisions antenne.

--- a/tests/rf/plan_vna.md
+++ b/tests/rf/plan_vna.md
@@ -1,0 +1,2 @@
+﻿# Plan VNA (Phase 4)
+- Calibration SOLT, plage 800–950 MHz, pas 100 kHz, moyenne 4.


### PR DESCRIPTION
Cette PR introduit les éléments suivants :
- Ajout des placeholders pour les livrables des phases 1 à 6 :
  - PCB embarqué (Phase 1)
  - Software & Lab concept (Phase 2)
  - Antenne 868 MHz (Phase 3)
  - Protocoles & tests préliminaires (Phase 4)
  - Tests instrumentés & validation intégrée (Phase 5)
  - Examen oral & rapport final (Phase
